### PR TITLE
Fix typo in github action.

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -33,7 +33,7 @@ jobs:
 
   build-and-upload:
     needs: test
-    if: startsWith(github.ref, 'ref/tags/v') # Only run if we're pushing a new version tag.
+    if: startsWith(github.ref, 'refs/tags/v') # Only run if we're pushing a new version tag.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This pull request includes a small but crucial fix in the `.github/workflows/pypi-publish.yml` file. The change corrects the conditional statement that determines when the `build-and-upload` job should run.

* Corrected the `if` condition in the `build-and-upload` job to ensure it correctly identifies version tags by changing `ref/tags/v` to `refs/tags/v`. (`.github/workflows/pypi-publish.yml`, [.github/workflows/pypi-publish.ymlL36-R36](diffhunk://#diff-29239970d55958739fb39189ad2b2b5afe4184fc541ccaa9ee3f91be06877f0fL36-R36))