### PR TITLE
Use dynamic version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/*
 django_queryset_erd.egg-info/*
 
 __pycache__/
+**/.DS_Store

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-queryset-erd
-version = 0.1.0
+version = attr: django_queryset_erd.__version__
 author = José Ernesto Dávila Pantoja
 author_email = josernestodavila@gmail.com
 description = Generate Entity-Relationship Diagrams from Django querysets


### PR DESCRIPTION
This pull request includes a change to the `setup.cfg` file to dynamically set the version number from the `django_queryset_erd` module.

* [`setup.cfg`](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L3-R3): Modified the `version` attribute to dynamically use the version from the `django_queryset_erd.__version__` attribute.- Update `setup.cfg` to use dynamic version.