### PR TITLE
Set Dynamic Version.

### DIFF
--- a/django_queryset_erd/__init__.py
+++ b/django_queryset_erd/__init__.py
@@ -1,3 +1,10 @@
+import importlib.metadata
+
 from .generator import generate_erd_from_queryset
 
-__version__ = '0.1.0'
+
+try:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
+


### PR DESCRIPTION
This pull request includes a change to dynamically set the version of the `django_queryset_erd` package using the `importlib.metadata` module. This change ensures that the package version is automatically retrieved from the package metadata, improving maintainability and accuracy.

* [`django_queryset_erd/__init__.py`](diffhunk://#diff-9ee6aa98665ad961b4dedc6bbe8d73afa9e828ad600bd90add35def779cd4e94R1-R10): Added `importlib.metadata` to dynamically set the `__version__` attribute, replacing the hardcoded version string.- Get the version based on the git tag.