### PR TITLE
Fix Version.

### DIFF
--- a/django_queryset_erd/__init__.py
+++ b/django_queryset_erd/__init__.py
@@ -1,10 +1,5 @@
-import importlib.metadata
-
 from .generator import generate_erd_from_queryset
 
+__version__ = "2024.10.1"
 
-try:
-    __version__ = importlib.metadata.version(__name__)
-except importlib.metadata.PackageNotFoundError:
-    __version__ = "unknown"
-
+__all__ = ["generate_erd_from_queryset"]


### PR DESCRIPTION
This pull request includes changes to the `django_queryset_erd/__init__.py` file that streamline the module's imports and versioning process.

* Removed the `importlib.metadata` import and the associated try-except block for setting the `__version__` variable. Instead, the version is now hardcoded.
* Added `__all__` to explicitly declare the public API of the module.