### PR TITLE
Jose/fix build action

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -6,6 +6,9 @@ on:
       - "v*" # Trigger on push of version tags (e.g., v1.0.0)
   pull_request:
     branches: [main] # Trigger on pull requests to main branch
+  paths:
+    - django_queryset_erd/** # Trigger on changes to the package code
+    - setup.cfg # Trigger on changes to the package metadata
 
 jobs:
   test:
@@ -15,9 +18,9 @@ jobs:
         python-version: ["3.10", "3.12"]
         django-version: ["4.2", "5.0"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
@@ -36,9 +39,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') # Only run if we're pushing a new version tag.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Install Dependencies


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for publishing to PyPI. The main changes involve updating the version of actions used and adding triggers for specific file changes.

Updates to GitHub Actions workflow:

* [`.github/workflows/pypi-publish.yml`](diffhunk://#diff-29239970d55958739fb39189ad2b2b5afe4184fc541ccaa9ee3f91be06877f0fR9-R11): Added paths to trigger the workflow on changes to `django_queryset_erd/**` and `setup.cfg`.
* [`.github/workflows/pypi-publish.yml`](diffhunk://#diff-29239970d55958739fb39189ad2b2b5afe4184fc541ccaa9ee3f91be06877f0fL18-R23): Updated `actions/checkout` from version 3 to 4 and `actions/setup-python` from version 4 to 5 in the `test` job.
* [`.github/workflows/pypi-publish.yml`](diffhunk://#diff-29239970d55958739fb39189ad2b2b5afe4184fc541ccaa9ee3f91be06877f0fL39-R44): Updated `actions/checkout` from version 3 to 4 and `actions/setup-python` from version 4 to 5 in the `publish` job.