### PR TITLE
Remove redundant action items.

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -6,9 +6,6 @@ on:
       - "v*" # Trigger on push of version tags (e.g., v1.0.0)
   pull_request:
     branches: [main] # Trigger on pull requests to main branch
-  paths:
-    - django_queryset_erd/** # Trigger on changes to the package code
-    - setup.cfg # Trigger on changes to the package metadata
 
 jobs:
   test:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/pypi-publish.yml` file to modify the conditions under which the workflow is triggered.

Workflow trigger modifications:

* Removed the `paths` condition to trigger the workflow on changes to the package code and metadata. This means the workflow will now only trigger on version tags and pull requests to the main branch. (`.github/workflows/pypi-publish.yml`)