### PR TITLE
Update GH actions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -53,11 +53,7 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload dist/*
       - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
+          files: dist/**
+          generate_release_notes: true


### PR DESCRIPTION
This pull request includes a significant update to the GitHub Actions workflow for publishing to PyPI. The most important change is the switch to a different action for creating GitHub releases, along with adjustments to the configuration for that action.

Changes to GitHub Actions workflow:

* [`.github/workflows/pypi-publish.yml`](diffhunk://#diff-29239970d55958739fb39189ad2b2b5afe4184fc541ccaa9ee3f91be06877f0fL56-R59): Replaced `actions/create-release@v1` with `softprops/action-gh-release@v2` for creating GitHub releases. Updated the configuration to include the `files` and `generate_release_notes` parameters.