### PR TITLE
Update version to 2025.01.1

### DIFF
--- a/django_queryset_erd/__init__.py
+++ b/django_queryset_erd/__init__.py
@@ -1,5 +1,5 @@
 from .generator import generate_erd_from_queryset
 
-__version__ = "2024.10.1"
+__version__ = "2025.01.1"
 
 __all__ = ["generate_erd_from_queryset"]


### PR DESCRIPTION
Bump the version number from 2024.10.1 to 2025.01.1 in the `__init__.py` file. This likely prepares the package for a new release or reflects recent changes.